### PR TITLE
Allow request registration functions to take params array/objct as a …

### DIFF
--- a/simple-jsonrpc-js.js
+++ b/simple-jsonrpc-js.js
@@ -227,7 +227,10 @@
                     var result;
 
                     if (request.hasOwnProperty('params')) {
-                        if (isArray(request.params)) {
+                        if (dispatcher[request.method].params == "pass") {
+                            result = dispatcher[request.method].fn.call(dispatcher, request.params);
+                        }
+                        else if (isArray(request.params)) {
                             result = dispatcher[request.method].fn.apply(dispatcher, request.params);
                         }
                         else if (isObject(request.params)) {
@@ -370,7 +373,13 @@
 
         self.dispatch = function (functionName, paramsNameFn, fn) {
 
-            if (isString(functionName) && isArray(paramsNameFn) && isFunction(fn)) {
+            if (isString(functionName) && paramsNameFn == "pass" && isFunction(fn)) {
+                dispatcher[functionName] = {
+                    fn: fn,
+                    params: paramsNameFn
+                };
+            }
+            else if (isString(functionName) && isArray(paramsNameFn) && isFunction(fn)) {
                 dispatcher[functionName] = {
                     fn: fn,
                     params: paramsNameFn


### PR DESCRIPTION
@jershell 

I have been using this library with the following modification for a while now, so I thought I'd share it with you. I have pre-existing functions that expect the params I am sending around as single arguments. These objects contain a fair number of keys that I don't want to have to express multiple times in the registration and function arguments. This patch allows the user to tell the dispatcher to pass the params array/object directly to the registered function by setting the second argument of on/dispatch to "pass".

No worries if you decide not to take this pull request, or decide to support this feature differently.