### PR TITLE
ability to tune default result

### DIFF
--- a/simple-jsonrpc-js.js
+++ b/simple-jsonrpc-js.js
@@ -106,6 +106,7 @@
             id = 0,
             dispatcher = {};
 
+        self.undefinedResult = true;
 
         function setError(jsonrpcError, exception) {
             var error = clone(jsonrpcError);
@@ -277,7 +278,7 @@
                         if (isPromise(result)) {
                             return result.then(function (res) {
                                 if (isUndefined(res)) {
-                                    res = true;
+                                    res = self.undefinedResult;
                                 }
                                 return {
                                     "jsonrpc": "2.0",
@@ -296,7 +297,7 @@
                         else {
 
                             if (isUndefined(result)) {
-                                result = true;
+                                result = self.undefinedResult;
                             }
 
                             return _Promise.resolve({


### PR DESCRIPTION
allow to set default result of locally called function if it returns
undefined

usage example:
```js
    jrpc.undefinedResult = null; // or false, or whatever
    jrpc.on('find', function(key) {
        if (db.exists(key))
	    return db.get(key);
	// If there is nothing found then just return nothing
    });
```